### PR TITLE
Makefile: fix gcc 'undefined reference' problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ install:	ansi2gif
 	cp ansi2eps /usr/local/bin
 
 ansi2gif:	ansi2gif.o pcfont.o
-	$(CC) $(LFLAGS) -o ansi2gif ansi2gif.o pcfont.o
+	$(CC) -o ansi2gif ansi2gif.o pcfont.o $(LFLAGS)
 	ln -f -s ansi2gif ansi2png
 	ln -f -s ansi2gif ansi2eps
 


### PR DESCRIPTION
gcc version: `gcc (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609`

[gcc is sensitive to the order in which linking flags are passed] (http://stackoverflow.com/a/8382223). The current argument order causes errors:

    gcc  -lgd -lm -o ansi2gif ansi2gif.o pcfont.o
    .../ansi2gif/ansi2gif.c:114: undefined reference to `gdImageColorAllocate'
    ... and more such errors ...

Moving the linking flags to the end of the invocation, as follows, runs without errors.

    gcc  -o ansi2gif ansi2gif.o pcfont.o -lgd -lm

The proposed patch fixes the Makefile accordingly.